### PR TITLE
Add baseline response security headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+*.tsbuildinfo
 
 # debug
 npm-debug.log*

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,18 @@
 module.exports = {
+  poweredByHeader: false,
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+        ],
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
Adds clickjacking, MIME-sniffing, referrer, feature-policy, and framework-disclosure protections without changing Paystack or PostHog connectivity. Verified with TypeScript and a production build.