### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install Yarn
+        run: npm install --global yarn@1.22.22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Type-check
+        run: yarn type-check
+
+      - name: Build
+        run: yarn build
+
+      - name: Audit production dependencies
+        run: yarn audit --groups dependencies --level high

--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ the browser or forwarded to analytics.
 ## Verification
 
 ```bash
+yarn type-check
 yarn build
+yarn audit --groups dependencies --level high
 ```

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
 	"name": "paystack",
 	"version": "1.0.0",
 	"private": true,
-	"scripts": {
-		"dev": "next dev",
-		"build": "next build",
-		"start": "next start"
-	},
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "type-check": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=22.22.0"
+  },
+  "packageManager": "yarn@1.22.22",
 	"dependencies": {
 		"next": "15.5.25",
 		"posthog-js": "1.428.3",


### PR DESCRIPTION
## Summary
- add a read-only Node 24 CI workflow
- enforce the runtime required by the current PostHog SDK
- type-check, build, and audit production dependencies on every change
- document the verification commands

## Verification
- `yarn install --frozen-lockfile --ignore-engines` (local host is Node 22.12; CI uses supported Node 24)
- `yarn type-check`
- `yarn build`
- `yarn audit --groups dependencies --level high` (0 vulnerabilities)