### PR TITLE
Turn Paystack playground into a safe services enquiry funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Paystack
 
-Paystack functionality demo in Next.js with TypeScript.
+Paystack checkout demonstration in Next.js with TypeScript, with a service enquiry
+link to https://tinotech.co.za/services. This is a lead-generation demo, not a
+standalone paid product. Live keys are rejected in the UI and verification API.
+The visitor can enter any test amount; never use this demo to fulfil paid orders.
+Product checkouts need server-created orders and exact product/amount/buyer binding,
+as implemented in `tinotech-co-za/Money` (ChaseKit).
 
 ## Environment
 

--- a/components/Paystack.tsx
+++ b/components/Paystack.tsx
@@ -19,12 +19,13 @@ const Paystack: React.FC = (): JSX.Element => {
   const [name, setName] = useState("");
   const [surname, setSurname] = useState("");
   const [success, setSuccess] = useState(false);
+  const [message, setMessage] = useState("");
 
   // Initialize reference and reset success state on mount
   useEffect(() => {
     setSuccess(false);
     setRef(window.crypto.randomUUID());
-  }, [success]);
+  }, []);
 
   const config: PaystackProps = {
     reference: ref,
@@ -38,6 +39,7 @@ const Paystack: React.FC = (): JSX.Element => {
   };
 
   const onSuccess = (reference: referenceObj) => {
+    setMessage("");
     fetch(`/api/verify/${reference.reference}`)
       .then((res) => res.json())
       .then((verifyData) => {
@@ -47,28 +49,31 @@ const Paystack: React.FC = (): JSX.Element => {
             currency: verifyData.data.currency,
           });
           setSuccess(true);
+          setRef(window.crypto.randomUUID());
           setEmail("");
           setAmount(0);
           setName("");
           setSurname("");
         } else {
+          setMessage("The test payment could not be verified. Please try again.");
           posthog.capture("failedPayment", {
             amount,
           });
         }
-      });
+      })
+      .catch(() => setMessage("Verification is temporarily unavailable. Please try again."));
   };
 
   const onClose = () => {
     posthog.capture("cancelledPayment", {
       amount,
     });
-    alert("Payment cancelled.");
+    setMessage("Test checkout cancelled.");
   };
 
   const componentProps = {
     ...config,
-    text: `Pay R${amount | 0}`,
+    text: `Test pay R${Number.isFinite(amount) ? amount.toFixed(2) : "0.00"}`,
     onSuccess,
     onClose,
   };
@@ -76,16 +81,22 @@ const Paystack: React.FC = (): JSX.Element => {
   // Validate required fields before rendering the button
   const isFormValid =
     email &&
+    Number.isFinite(amount) &&
     amount > 0 &&
+    amount <= 1000000 &&
     name &&
     surname &&
-    process.env.NEXT_PUBLIC_PAYSTACK_PUBLIC_TEST_KEY;
+    process.env.NEXT_PUBLIC_PAYSTACK_PUBLIC_TEST_KEY?.startsWith("pk_test_");
 
   return (
     <div className="glass-card">
+      <h1>Try a Paystack checkout</h1>
+      <p>This is a test checkout demonstration. It does not sell a product or accept live payments.</p>
+      <p><a href="https://tinotech.co.za/services">Need checkout on your website? View tinotech services.</a></p>
+      {message && <p role="status">{message}</p>}
       {success && (
         <div className="success-message">
-          Payment successful! Thank you for your transaction.
+          Test payment verified. No product was purchased.
         </div>
       )}
       <div id="paymentForm">

--- a/pages/api/verify/[reference].ts
+++ b/pages/api/verify/[reference].ts
@@ -30,7 +30,7 @@ export default async (req: NextApiRequest, resp: NextApiResponse<Data>) => {
   ) {
     return resp.status(400).json({ success: false });
   }
-  if (!secretKey) {
+  if (!secretKey?.startsWith("sk_test_")) {
     return resp.status(503).json({ success: false });
   }
 
@@ -50,13 +50,15 @@ export default async (req: NextApiRequest, resp: NextApiResponse<Data>) => {
       `https://api.paystack.co/transaction/verify/${reference}`,
       {
         method: "GET",
+        signal: AbortSignal.timeout(10000),
+        cache: "no-store",
         headers: {
           Authorization: `Bearer ${secretKey}`,
         },
       }
     );
     const payload: any = await res.json();
-    if (!res.ok || payload?.status !== true || !payload?.data) {
+    if (!res.ok || payload?.status !== true || !payload?.data || payload.data.reference !== reference || payload.data.domain !== "test" || payload.data.currency !== "ZAR") {
       console.error("Paystack verification failed", res.status);
       return resp.status(502).json({ success: false });
     }
@@ -97,6 +99,6 @@ export default async (req: NextApiRequest, resp: NextApiResponse<Data>) => {
     return resp.status(502).json({ success: false });
   } finally {
     // Ensure PostHog client is properly shut down
-    await posthog?.shutdown();
+    try { await posthog?.shutdown(); } catch { /* Analytics must not change the verification result. */ }
   }
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,8 @@ const Home: React.FC = (): JSX.Element => {
   return (
     <>
       <Head>
-        <title>Paystack Playground</title>
+        <title>Paystack checkout demo | tinotech</title>
+        <meta name="description" content="Try a safe Paystack test checkout, then ask tinotech to integrate payments on your business website." />
       </Head>
       <div className="background-elements"></div>
       <main>


### PR DESCRIPTION
Make the Paystack playground a clearly labelled test-only demonstration that directs interested businesses to Tinotech's services page: https://www.tinotech.co.za/services.

The UI and verification endpoint reject live keys. Successful test payments remain visible, amounts display cents correctly, and verification/network failures provide feedback. No product is sold or fulfilled by this demo.

Live demo: https://paystack-blue.vercel.app. Deployed source `c4333a6` to the existing `tinomuzambi/paystack` project, preserving its domain and original test credentials. Added `NEXT_PUBLIC_PAYSTACK_PUBLIC_TEST_KEY` as the browser alias of the existing public test key.

Validation: TypeScript, production build and dependency audit pass (zero reported vulnerabilities). The deployed browser shows the test-only notice, the service CTA points to the actual services page, and a synthetic R12.34 checkout opens Paystack's TEST flow with the correct amount. Checkout was not completed; no real charge was made.

Deployment: https://paystack-j10durono-tinomuzambi.vercel.app (`dpl_FkKjLp3oZ2VPgPZ3QbAMKF91jQGn`).
